### PR TITLE
feat: Diff function

### DIFF
--- a/date.go
+++ b/date.go
@@ -227,6 +227,36 @@ func (d Date) Value() (driver.Value, error) {
 	return d.String(), nil
 }
 
+// Diff finds the difference in years, months, and days between two provided dates.
+// The dates can be provided in any order, or can be equal.
+//
+// Returns 3 integers representing the number of years, months, and days
+// separating the two dates. These values are non-contiguous and should be taken
+// as standalone values, e.g., the diff between Feb 1st 2001 and March 1st 2002
+// would be 1 year, 13 months, and 393 days.
+func Diff(d1, d2 Date) (year int, month int, day int) {
+	if d2 < d1 {
+		d1, d2 = d2, d1
+	}
+	y, m, d := d1, d1, d1
+	for y.Year() < d2.Year() {
+		y = y.AddYears(1)
+		year += 1
+	}
+	for m.Month() < d2.Month() {
+		m = m.AddMonths(1)
+		month += 1
+	}
+	for d < d2 {
+		d = d.AddDays(1)
+		day += 1
+	}
+
+	month += year * 12
+
+	return
+}
+
 // Max finds the maximum date (furthest in the direction of the future) out of
 // the two given dates.
 func Max(d1, d2 Date) Date {

--- a/date_test.go
+++ b/date_test.go
@@ -360,3 +360,110 @@ func TestNullDateJSONNull(t *testing.T) {
 		t.Fatalf("Did not decode correctly, should be not valid")
 	}
 }
+
+func TestDiff(t *testing.T) {
+
+	type want struct {
+		year  int
+		month int
+		day   int
+	}
+
+	tests := map[string]struct {
+		d1   Date
+		d2   Date
+		want want
+	}{
+		"1 year diff": {
+			d1: MustFromString("2001-01-01"),
+			d2: MustFromString("2002-01-01"),
+			want: want{
+				year:  1,
+				month: 12,
+				day:   365,
+			},
+		},
+		"1 year diff leap year": {
+			d1: MustFromString("2000-01-01"),
+			d2: MustFromString("2001-01-01"),
+			want: want{
+				year:  1,
+				month: 12,
+				day:   366,
+			},
+		},
+		"1 month diff": {
+			d1: MustFromString("2000-01-01"),
+			d2: MustFromString("2000-02-01"),
+			want: want{
+				year:  0,
+				month: 1,
+				day:   31,
+			},
+		},
+		"1 day diff": {
+			d1: MustFromString("2000-01-01"),
+			d2: MustFromString("2000-01-02"),
+			want: want{
+				year:  0,
+				month: 0,
+				day:   1,
+			},
+		},
+		"1 year, 1 month, 1 day": {
+			d1: MustFromString("2001-02-01"),
+			d2: MustFromString("2002-03-01"),
+			want: want{
+				year:  1,
+				month: 13,
+				day:   393,
+			},
+		},
+		"negative diff": {
+			d1: MustFromString("2002-01-01"),
+			d2: MustFromString("2001-01-01"),
+			want: want{
+				year:  1,
+				month: 12,
+				day:   365,
+			},
+		},
+		"equal dates": {
+			d1: MustFromString("2000-01-01"),
+			d2: MustFromString("2000-01-01"),
+			want: want{
+				year:  0,
+				month: 0,
+				day:   0,
+			},
+		},
+		"february": {
+			d1: MustFromString("2001-02-01"),
+			d2: MustFromString("2001-03-01"),
+			want: want{
+				year:  0,
+				month: 1,
+				day:   28,
+			},
+		},
+		"february leap year": {
+			d1: MustFromString("2000-02-01"),
+			d2: MustFromString("2000-03-01"),
+			want: want{
+				year:  0,
+				month: 1,
+				day:   29,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			y, m, d := Diff(tt.d1, tt.d2)
+			if y != tt.want.year || m != tt.want.month || d != tt.want.day {
+				t.Fatalf("Got Year: %d, Month: %d, Day: %d, want Year: %d, Month: %d, Day: %d", y, m, d, tt.want.year, tt.want.month, tt.want.day)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION

## Description

This PR adds a new `Diff` function, which calculates the difference between two dates. The returned values are non-contiguous and should be taken in isolation.

Dates can be provided in any order, though the returned values will always be absolute. The difference between `2000-02-01` and `2001-02-01` is the same as `2001-02-01` and `2000-02-01`.

## Checklist ([Reference](https://spaceship-hq.atlassian.net/wiki/spaces/EG/pages/353337566/This+is+how+we+GO#Backend-PR-checklist))

- [ ] Secure
- [ ] Performant
- [ ] Scalable
- [ ] Idempotent
- [ ] Deduplicates
- [ ] Thread safe
- [ ] Maintains visibility
